### PR TITLE
add cloud manager baseUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Check the end of the page for instructions on how to remove the Operator.
 
 For the Operator to work, you will need the following information:
 
-* Base Url - the url of an Ops Manager instance
+* Base Url - the url of an Ops Manager instance, for Cloud Manger use `https://cloud.mongodb.com`.
 * Project Name - the name of an Ops Manager Project where MongoDBs will be deployed into. It will be created by Operator
  if it doesn't exist (and this is the recommended way instead of reusing the project created in OpsManager directly)
 * (optionally) Organization Id - the id of organization to which Project belongs


### PR DESCRIPTION
in the main docs on
`https://docs.mongodb.com/kubernetes-operator/master/tutorial/create-project-using-configmap/#create-k8s-project`
it stated to use `Cloud Manager` for baseUrl, which leads to an error `unsupported protocol scheme ""` on the operator pod
the right value should be set to `https://cloud.mongodb.com`