### PR TITLE
Minor fixes for installing/running mongodb enterprise operator

### DIFF
--- a/samples/mongodb/minimal/replica-set.yaml
+++ b/samples/mongodb/minimal/replica-set.yaml
@@ -7,6 +7,7 @@ apiVersion: mongodb.com/v1
 kind: MongoDB
 metadata:
   name: my-replica-set
+  namespace: mongodb
 spec:
   members: 3
   version: 4.4.0-ent
@@ -29,7 +30,7 @@ spec:
             resources:
               limits:
                 cpu: "2"
-                memory: 700m
+                memory: 700M
               requests:
                 cpu: "1"
-                memory: 500m
+                memory: 500M


### PR DESCRIPTION
* Set namespace for MongoDb Replicaset resource as "mongodb": As per the docs: https://github.com/mongodb/mongodb-enterprise-kubernetes#creating-a-mongodb-resource the mdb resource gets created in the "default" namespace which is not being watched by the operator in the default topology. So we should specify the namespace explicitly in replica-set.yaml as "MongoDB".
* Fix the unit for memory in replica-set.yaml: Currently the unit is set to "m" which is not a valid memory unit, this was throwing an obscure error message from kubelet which attempting to start the pod. Changed the unit to "M".

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

