### PR TITLE
update replica-set-backup.yaml

### DIFF
--- a/samples/mongodb/backup/replica-set-backup.yaml
+++ b/samples/mongodb/backup/replica-set-backup.yaml
@@ -13,4 +13,4 @@ spec:
       name: my-project
   credentials: my-credentials
   backup:
-    enabled: true
+    mode: enabled


### PR DESCRIPTION
Based on the https://docs.mongodb.com/kubernetes-operator/master/reference/k8s-operator-specification/#spec.backup.mode

we need to pass `spec.backup.mode` to enables continuous backups for MongoDB resources in Kubernetes Operator 1.9.0

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [* ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [* ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

