### PR TITLE
Helm: Remove namespace from Cluster-wide resources

### DIFF
--- a/helm_chart/templates/operator-roles.yaml
+++ b/helm_chart/templates/operator-roles.yaml
@@ -113,7 +113,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.operator.name }}-{{ .Values.namespace }}-webhook-binding
-  namespace: {{ .Values.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
* [ ] Have you opened an Issue before filing this PR?
* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

Hey, it seems, I can't open an issue, so this is only the pr.
The Kubernetes API excepts namespaces in cluster-scoped resources, but for some tools, this fails before deploying the resources. So this removes the namespace from a ClusterRoleBinding