### PR TITLE
Added chart's values to support nodeSelector, tolerations and affinity

### DIFF
--- a/helm_chart/templates/operator.yaml
+++ b/helm_chart/templates/operator.yaml
@@ -126,6 +126,22 @@ spec:
             defaultMode: 420
             secretName: {{ .Values.multiCluster.kubeConfigSecretName }}
 {{- end }}
+
+{{- with .Values.operator }}
+  {{- with .nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+  {{- end }}
+{{- end }}
+
 {{- if .Values.debug }}
 ---
 apiVersion: v1

--- a/helm_chart/values-openshift.yaml
+++ b/helm_chart/values-openshift.yaml
@@ -26,6 +26,12 @@ operator:
   - opsmanagers
   - mongodbusers
 
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
 ## Database
 database:
   name: enterprise-database

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -31,6 +31,12 @@ operator:
 
   # Create operator-service account
   createOperatorServiceAccount: true
+  
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
 
 ## Database
 database:


### PR DESCRIPTION
Hi, 

This PR brings the options nodeSelector, tolerations and affinity into values.yaml that gives more control over where the operator is spawned in a cluster.


### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

