### PR TITLE
Kubernetes Enterprise Operator Release 1.16.2

### DIFF
--- a/crds.yaml
+++ b/crds.yaml
@@ -112,9 +112,6 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               configSrvPodSpec:
                 properties:
-                  nodeAffinity:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
                   persistence:
                     properties:
                       multiple:
@@ -161,11 +158,6 @@ spec:
                             type: string
                         type: object
                     type: object
-                  podAffinity:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  podAntiAffinityTopologyKey:
-                    type: string
                   podTemplate:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
@@ -226,9 +218,6 @@ spec:
                 type: integer
               mongosPodSpec:
                 properties:
-                  nodeAffinity:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
                   persistence:
                     properties:
                       multiple:
@@ -275,11 +264,6 @@ spec:
                             type: string
                         type: object
                     type: object
-                  podAffinity:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  podAntiAffinityTopologyKey:
-                    type: string
                   podTemplate:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
@@ -296,9 +280,6 @@ spec:
                 type: boolean
               podSpec:
                 properties:
-                  nodeAffinity:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
                   persistence:
                     properties:
                       multiple:
@@ -345,11 +326,6 @@ spec:
                             type: string
                         type: object
                     type: object
-                  podAffinity:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  podAntiAffinityTopologyKey:
-                    type: string
                   podTemplate:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
@@ -624,9 +600,6 @@ spec:
                 type: integer
               shardPodSpec:
                 properties:
-                  nodeAffinity:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
                   persistence:
                     properties:
                       multiple:
@@ -673,11 +646,6 @@ spec:
                             type: string
                         type: object
                     type: object
-                  podAffinity:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  podAntiAffinityTopologyKey:
-                    type: string
                   podTemplate:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
@@ -1665,9 +1633,6 @@ spec:
                     type: object
                   podSpec:
                     properties:
-                      nodeAffinity:
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
                       persistence:
                         properties:
                           multiple:
@@ -1714,11 +1679,6 @@ spec:
                                 type: string
                             type: object
                         type: object
-                      podAffinity:
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
-                      podAntiAffinityTopologyKey:
-                        type: string
                       podTemplate:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true

--- a/mongodb-enterprise-openshift.yaml
+++ b/mongodb-enterprise-openshift.yaml
@@ -189,7 +189,7 @@ spec:
       serviceAccountName: mongodb-enterprise-operator
       containers:
       - name: mongodb-enterprise-operator
-        image: registry.connect.redhat.com/mongodb/enterprise-operator:1.16.1
+        image: registry.connect.redhat.com/mongodb/enterprise-operator:1.16.2
         imagePullPolicy: Always
         args:
         - -watch-resource=mongodb

--- a/mongodb-enterprise.yaml
+++ b/mongodb-enterprise.yaml
@@ -192,7 +192,7 @@ spec:
         runAsUser: 2000
       containers:
       - name: mongodb-enterprise-operator
-        image: quay.io/mongodb/mongodb-enterprise-operator:1.16.1
+        image: quay.io/mongodb/mongodb-enterprise-operator:1.16.2
         imagePullPolicy: Always
         args:
         - -watch-resource=mongodb

--- a/samples/mongodb_multi/replica-set-configure-storage.yaml
+++ b/samples/mongodb_multi/replica-set-configure-storage.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   version: 4.4.0-ent
   type: ReplicaSet
-  persistent: false
   duplicateServiceObjects: false
   credentials: my-credentials
   opsManager:
@@ -26,13 +25,14 @@ spec:
                   image: busybox
                   command: ["sleep"]
                   args: [ "infinity" ]
-            # to override the default storage class for the pv
+            # to override the default storage size of the "data" PV
             volumeClaimTemplates:
             - metadata:
                 name: data
               spec:
-                accessModes: [ "ReadWriteOnce" ]
-                storageClassName: "gp2"
+                resources:
+                  requests:
+                    storage: 1Gi
       - clusterName: cluster2.mongokubernetes.com
         members: 1
         statefulSet:
@@ -44,12 +44,13 @@ spec:
                   image: busybox
                   command: ["sleep"]
                   args: [ "infinity" ]
-            volumeClaimTemplates:
-            - metadata:
+              volumeClaimTemplates:
+              - metadata:
                 name: data
               spec:
-                accessModes: [ "ReadWriteOnce" ]
-                storageClassName: "gp2"
+                resources:
+                  requests:
+                    storage: 1Gi
       - clusterName: cluster3.mongokubernetes.com
         members: 1
         statefulSet:
@@ -61,9 +62,11 @@ spec:
                   image: busybox
                   command: ["sleep"]
                   args: [ "infinity" ]
-            volumeClaimTemplates:
-            - metadata:
+              volumeClaimTemplates:
+              - metadata:
                 name: data
               spec:
-                accessModes: [ "ReadWriteOnce" ]
-                storageClassName: "gp2"
+                resources:
+                  requests:
+                    storage: 1Gi
+                


### PR DESCRIPTION
## Kubernetes Enterprise Operator Release 1.16.2


This release patch has been created and it should be reviewed now.


You can add new commits to this patch if needed. After changes have
been reviewed, merge this PR for PCT to continue the release process.