### PR TITLE
Kubernetes Enterprise Operator Release 1.16.3

### DIFF
--- a/crds.yaml
+++ b/crds.yaml
@@ -464,11 +464,15 @@ spec:
                             items:
                               type: string
                             type: array
+                          timeoutMS:
+                            type: integer
                           transportSecurity:
                             enum:
                             - tls
                             - none
                             type: string
+                          userCacheInvalidationInterval:
+                            type: integer
                           userToDNMapping:
                             type: string
                           validateLDAPServerConfig:
@@ -1021,11 +1025,15 @@ spec:
                             items:
                               type: string
                             type: array
+                          timeoutMS:
+                            type: integer
                           transportSecurity:
                             enum:
                             - tls
                             - none
                             type: string
+                          userCacheInvalidationInterval:
+                            type: integer
                           userToDNMapping:
                             type: string
                           validateLDAPServerConfig:
@@ -1826,11 +1834,15 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              timeoutMS:
+                                type: integer
                               transportSecurity:
                                 enum:
                                 - tls
                                 - none
                                 type: string
+                              userCacheInvalidationInterval:
+                                type: integer
                               userToDNMapping:
                                 type: string
                               validateLDAPServerConfig:

--- a/mongodb-enterprise-openshift.yaml
+++ b/mongodb-enterprise-openshift.yaml
@@ -189,7 +189,7 @@ spec:
       serviceAccountName: mongodb-enterprise-operator
       containers:
       - name: mongodb-enterprise-operator
-        image: registry.connect.redhat.com/mongodb/enterprise-operator:1.16.2
+        image: registry.connect.redhat.com/mongodb/enterprise-operator:1.16.3
         imagePullPolicy: Always
         args:
         - -watch-resource=mongodb
@@ -225,7 +225,7 @@ spec:
         - name: INIT_DATABASE_IMAGE_REPOSITORY
           value: registry.connect.redhat.com/mongodb/mongodb-enterprise-init-database
         - name: INIT_DATABASE_VERSION
-          value: 1.0.9
+          value: 1.0.10
         - name: DATABASE_VERSION
           value: 2.0.2
         # Ops Manager
@@ -239,7 +239,7 @@ spec:
         - name: INIT_APPDB_IMAGE_REPOSITORY
           value: registry.connect.redhat.com/mongodb/mongodb-enterprise-init-appdb
         - name: INIT_APPDB_VERSION
-          value: 1.0.9
+          value: 1.0.10
         - name: OPS_MANAGER_IMAGE_PULL_POLICY
           value: Always
         - name: AGENT_IMAGE

--- a/mongodb-enterprise.yaml
+++ b/mongodb-enterprise.yaml
@@ -192,7 +192,7 @@ spec:
         runAsUser: 2000
       containers:
       - name: mongodb-enterprise-operator
-        image: quay.io/mongodb/mongodb-enterprise-operator:1.16.2
+        image: quay.io/mongodb/mongodb-enterprise-operator:1.16.3
         imagePullPolicy: Always
         args:
         - -watch-resource=mongodb
@@ -226,7 +226,7 @@ spec:
         - name: INIT_DATABASE_IMAGE_REPOSITORY
           value: quay.io/mongodb/mongodb-enterprise-init-database
         - name: INIT_DATABASE_VERSION
-          value: 1.0.9
+          value: 1.0.10
         - name: DATABASE_VERSION
           value: 2.0.2
         # Ops Manager
@@ -240,7 +240,7 @@ spec:
         - name: INIT_APPDB_IMAGE_REPOSITORY
           value: quay.io/mongodb/mongodb-enterprise-init-appdb
         - name: INIT_APPDB_VERSION
-          value: 1.0.9
+          value: 1.0.10
         - name: OPS_MANAGER_IMAGE_PULL_POLICY
           value: Always
         - name: AGENT_IMAGE

--- a/samples/mongodb/authentication/ldap/replica-set/replica-set-ldap.yaml
+++ b/samples/mongodb/authentication/ldap/replica-set/replica-set-ldap.yaml
@@ -51,3 +51,17 @@ spec:
         bindQueryPasswordSecretRef:
           name: "<secret-name>"
 
+        # Select True to validate the LDAP server configuration or False to skip validation.
+        validateLDAPServerConfig: false
+
+        # LDAP-formatted query URL template executed by MongoDB to obtain the LDAP groups that the user belongs to
+        authzQueryTemplate: "{USER}?memberOf?base"
+
+        # Maps the username provided to mongod or mongos for authentication to an LDAP Distinguished Name (DN).
+        userToDNMapping: '[{match: "CN=mms-automation-agent,(.+),L=NY,ST=NY,C=US", substitution: "uid=mms-automation-agent,{0},dc=example,dc=org"}, {match: "(.+)", substitution:"uid={0},ou=groups,dc=example,dc=org"}]'
+
+        # Specify how long an authentication request should wait before timing out. In milliseconds.
+        timeoutMS: 10000
+
+        # Specify how long MongoDB waits to flush the LDAP user cache. In seconds.
+        userCacheInvalidationInterval: 30

--- a/samples/mongodb/mongodb-options/replica-set-mongod-options.yaml
+++ b/samples/mongodb/mongodb-options/replica-set-mongod-options.yaml
@@ -15,6 +15,5 @@ spec:
   additionalMongodConfig:
     systemLog:
       logAppend: true
-      verbosity: 4
-    operationProfiling:
-      mode: slowOp
+    systemLog.verbosity: 4
+    operationProfiling.mode: slowOp

--- a/samples/ops-manager/ops-manager-remote-mode.yaml
+++ b/samples/ops-manager/ops-manager-remote-mode.yaml
@@ -20,8 +20,6 @@ spec:
   applicationDatabase:
     version: "4.4.11-ent"
     members: 3
-    persistent: true
-
 ---
 # The nginx deployment allows to deploy the web server that will serve mongodb binaries to the MongoDBOpsManager resource
 # The example below provides the binaries for 4.4.0 mongodb (community and enterprise) for ubuntu and rhel (necessary if


### PR DESCRIPTION
## Kubernetes Enterprise Operator Release 1.16.3


This release patch has been created and it should be reviewed now.


You can add new commits to this patch if needed. After changes have
been reviewed, merge this PR for PCT to continue the release process.