### PR TITLE
Kubernetes Enterprise Operator Release 1.16.4

### DIFF
--- a/mongodb-enterprise-openshift.yaml
+++ b/mongodb-enterprise-openshift.yaml
@@ -189,7 +189,7 @@ spec:
       serviceAccountName: mongodb-enterprise-operator
       containers:
       - name: mongodb-enterprise-operator
-        image: registry.connect.redhat.com/mongodb/enterprise-operator:1.16.3
+        image: registry.connect.redhat.com/mongodb/enterprise-operator:1.16.4
         imagePullPolicy: Always
         args:
         - -watch-resource=mongodb
@@ -225,7 +225,7 @@ spec:
         - name: INIT_DATABASE_IMAGE_REPOSITORY
           value: registry.connect.redhat.com/mongodb/mongodb-enterprise-init-database
         - name: INIT_DATABASE_VERSION
-          value: 1.0.10
+          value: 1.0.11
         - name: DATABASE_VERSION
           value: 2.0.2
         # Ops Manager
@@ -234,12 +234,12 @@ spec:
         - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
           value: registry.connect.redhat.com/mongodb/mongodb-enterprise-init-ops-manager
         - name: INIT_OPS_MANAGER_VERSION
-          value: 1.0.7
+          value: 1.0.8
         # AppDB
         - name: INIT_APPDB_IMAGE_REPOSITORY
           value: registry.connect.redhat.com/mongodb/mongodb-enterprise-init-appdb
         - name: INIT_APPDB_VERSION
-          value: 1.0.10
+          value: 1.0.11
         - name: OPS_MANAGER_IMAGE_PULL_POLICY
           value: Always
         - name: AGENT_IMAGE

--- a/mongodb-enterprise.yaml
+++ b/mongodb-enterprise.yaml
@@ -192,7 +192,7 @@ spec:
         runAsUser: 2000
       containers:
       - name: mongodb-enterprise-operator
-        image: quay.io/mongodb/mongodb-enterprise-operator:1.16.3
+        image: quay.io/mongodb/mongodb-enterprise-operator:1.16.4
         imagePullPolicy: Always
         args:
         - -watch-resource=mongodb
@@ -226,7 +226,7 @@ spec:
         - name: INIT_DATABASE_IMAGE_REPOSITORY
           value: quay.io/mongodb/mongodb-enterprise-init-database
         - name: INIT_DATABASE_VERSION
-          value: 1.0.10
+          value: 1.0.11
         - name: DATABASE_VERSION
           value: 2.0.2
         # Ops Manager
@@ -235,12 +235,12 @@ spec:
         - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
           value: quay.io/mongodb/mongodb-enterprise-init-ops-manager
         - name: INIT_OPS_MANAGER_VERSION
-          value: 1.0.7
+          value: 1.0.8
         # AppDB
         - name: INIT_APPDB_IMAGE_REPOSITORY
           value: quay.io/mongodb/mongodb-enterprise-init-appdb
         - name: INIT_APPDB_VERSION
-          value: 1.0.10
+          value: 1.0.11
         - name: OPS_MANAGER_IMAGE_PULL_POLICY
           value: Always
         - name: AGENT_IMAGE

--- a/tools/multicluster/go.mod
+++ b/tools/multicluster/go.mod
@@ -1,6 +1,6 @@
 module github.com/10gen/ops-manager-kubernetes/multi
 
-go 1.17
+go 1.18
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
## Kubernetes Enterprise Operator Release 1.16.4


This release patch has been created and it should be reviewed now.


You can add new commits to this patch if needed. After changes have
been reviewed, merge this PR for PCT to continue the release process.