### PR TITLE
Kubernetes Enterprise Operator Release 1.17.1

### DIFF
--- a/mongodb-enterprise-openshift.yaml
+++ b/mongodb-enterprise-openshift.yaml
@@ -189,7 +189,7 @@ spec:
       serviceAccountName: mongodb-enterprise-operator
       containers:
       - name: mongodb-enterprise-operator
-        image: registry.connect.redhat.com/mongodb/enterprise-operator:1.17.0
+        image: quay.io/mongodb/mongodb-enterprise-operator-ubi:1.17.1
         imagePullPolicy: Always
         args:
         - -watch-resource=mongodb
@@ -221,32 +221,104 @@ spec:
           value: Always
         # Database
         - name: MONGODB_ENTERPRISE_DATABASE_IMAGE
-          value: registry.connect.redhat.com/mongodb/enterprise-database
+          value: quay.io/mongodb/mongodb-enterprise-database-ubi
         - name: INIT_DATABASE_IMAGE_REPOSITORY
-          value: registry.connect.redhat.com/mongodb/mongodb-enterprise-init-database
+          value: quay.io/mongodb/mongodb-enterprise-init-database-ubi
         - name: INIT_DATABASE_VERSION
           value: 1.0.12
         - name: DATABASE_VERSION
           value: 2.0.2
         # Ops Manager
         - name: OPS_MANAGER_IMAGE_REPOSITORY
-          value: registry.connect.redhat.com/mongodb/mongodb-enterprise-ops-manager
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
         - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
-          value: registry.connect.redhat.com/mongodb/mongodb-enterprise-init-ops-manager
+          value: quay.io/mongodb/mongodb-enterprise-init-ops-manager-ubi
         - name: INIT_OPS_MANAGER_VERSION
           value: 1.0.9
         # AppDB
         - name: INIT_APPDB_IMAGE_REPOSITORY
-          value: registry.connect.redhat.com/mongodb/mongodb-enterprise-init-appdb
+          value: quay.io/mongodb/mongodb-enterprise-init-appdb-ubi
         - name: INIT_APPDB_VERSION
           value: 1.0.12
         - name: OPS_MANAGER_IMAGE_PULL_POLICY
           value: Always
         - name: AGENT_IMAGE
-          value: registry.connect.redhat.com/mongodb/mongodb-agent:11.12.0.7388-1
+          value: quay.io/mongodb/mongodb-agent-ubi:11.12.0.7388-1
         - name: MONGODB_IMAGE
-          value: mongodb-enterprise-appdb-database
+          value: mongodb-enterprise-appdb-database-ubi
         - name: MONGODB_REPO_URL
           value: quay.io/mongodb
         - name: PERFORM_FAILOVER
           value: 'true'
+        - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_2_0_2
+          value: quay.io/mongodb/mongodb-enterprise-database-ubi:2.0.2
+        - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_0_12
+          value: quay.io/mongodb/mongodb-enterprise-init-database-ubi:1.0.12
+        - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_0_9
+          value: quay.io/mongodb/mongodb-enterprise-init-ops-manager-ubi:1.0.9
+        - name: RELATED_IMAGE_INIT_APPDB_IMAGE_REPOSITORY_1_0_12
+          value: quay.io/mongodb/mongodb-enterprise-init-appdb-ubi:1.0.12
+        - name: RELATED_IMAGE_AGENT_IMAGE_11_0_5_6963_1
+          value: quay.io/mongodb/mongodb-agent-ubi:11.0.5.6963-1
+        - name: RELATED_IMAGE_AGENT_IMAGE_11_12_0_7388_1
+          value: quay.io/mongodb/mongodb-agent-ubi:11.12.0.7388-1
+        - name: RELATED_IMAGE_AGENT_IMAGE_12_0_4_7554_1
+          value: quay.io/mongodb/mongodb-agent-ubi:12.0.4.7554-1
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_0
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.0
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_1
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.1
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_2
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.2
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_3
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.3
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_4
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.4
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_5
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.5
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_6
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.6
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_7
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.7
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_8
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.8
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_9
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.9
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_10
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.10
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_11
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.11
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_12
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.12
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_13
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.13
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_14
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.14
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_15
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.15
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_6_0_0
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:6.0.0
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_6_0_1
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:6.0.1
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_6_0_2
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:6.0.2
+        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_6_0_3
+          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:6.0.3
+        - name: RELATED_IMAGE_MONGODB_IMAGE_4_2_11_ent
+          value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.2.11-ent
+        - name: RELATED_IMAGE_MONGODB_IMAGE_4_2_2_ent
+          value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.2.2-ent
+        - name: RELATED_IMAGE_MONGODB_IMAGE_4_2_6_ent
+          value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.2.6-ent
+        - name: RELATED_IMAGE_MONGODB_IMAGE_4_2_8_ent
+          value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.2.8-ent
+        - name: RELATED_IMAGE_MONGODB_IMAGE_4_4_0_ent
+          value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.4.0-ent
+        - name: RELATED_IMAGE_MONGODB_IMAGE_4_4_11_ent
+          value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.4.11-ent
+        - name: RELATED_IMAGE_MONGODB_IMAGE_4_4_4_ent
+          value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.4.4-ent
+        - name: RELATED_IMAGE_MONGODB_IMAGE_5_0_1_ent
+          value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:5.0.1-ent
+        - name: RELATED_IMAGE_MONGODB_IMAGE_5_0_5_ent
+          value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:5.0.5-ent

--- a/mongodb-enterprise.yaml
+++ b/mongodb-enterprise.yaml
@@ -192,7 +192,7 @@ spec:
         runAsUser: 2000
       containers:
       - name: mongodb-enterprise-operator
-        image: quay.io/mongodb/mongodb-enterprise-operator:1.17.0
+        image: quay.io/mongodb/mongodb-enterprise-operator:1.17.1
         imagePullPolicy: Always
         args:
         - -watch-resource=mongodb


### PR DESCRIPTION
## Kubernetes Enterprise Operator Release 1.17.1


This release patch has been created and it should be reviewed now.


You can add new commits to this patch if needed. After changes have
been reviewed, merge this PR for PCT to continue the release process.