### PR TITLE
Kubernetes Enterprise Operator Release 1.18.0

### DIFF
--- a/crds.yaml
+++ b/crds.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: mongodb.mongodb.com
 spec:
@@ -71,17 +70,130 @@ spec:
                 description: Backup contains configuration options for configuring
                   backup for this MongoDB resource
                 properties:
+                  assignmentLabels:
+                    description: Assignment Labels set in the Ops Manager
+                    items:
+                      type: string
+                    type: array
                   autoTerminateOnDeletion:
                     description: AutoTerminateOnDeletion indicates if the Operator
                       should stop and terminate the Backup before the cleanup, when
                       the MongoDB CR is deleted
                     type: boolean
+                  encryption:
+                    description: Encryption settings
+                    properties:
+                      kmip:
+                        description: Kmip corresponds to the KMIP configuration assigned
+                          to the Ops Manager Project's configuration.
+                        properties:
+                          client:
+                            description: KMIP Client configuration
+                            properties:
+                              clientCertificatePrefix:
+                                description: 'A prefix used to construct KMIP client
+                                  certificate (and corresponding password) Secret
+                                  names. The names are generated using the following
+                                  pattern: KMIP Client Certificate (TLS Secret): <clientCertificatePrefix>-<CR
+                                  Name>-kmip-client KMIP Client Certificate Password:
+                                  <clientCertificatePrefix>-<CR Name>-kmip-client-password
+                                  The expected key inside is called "password".'
+                                type: string
+                            type: object
+                        required:
+                        - client
+                        type: object
+                    type: object
                   mode:
                     enum:
                     - enabled
                     - disabled
                     - terminated
                     type: string
+                  snapshotSchedule:
+                    properties:
+                      clusterCheckpointIntervalMin:
+                        enum:
+                        - 15
+                        - 30
+                        - 60
+                        type: integer
+                      dailySnapshotRetentionDays:
+                        description: Number of days to retain daily snapshots. Setting
+                          0 will disable this rule.
+                        maximum: 365
+                        minimum: 0
+                        type: integer
+                      fullIncrementalDayOfWeek:
+                        description: Day of the week when Ops Manager takes a full
+                          snapshot. This ensures a recent complete backup. Ops Manager
+                          sets the default value to SUNDAY.
+                        enum:
+                        - SUNDAY
+                        - MONDAY
+                        - TUESDAY
+                        - WEDNESDAY
+                        - THURSDAY
+                        - FRIDAY
+                        - SATURDAY
+                        type: string
+                      monthlySnapshotRetentionMonths:
+                        description: Number of months to retain weekly snapshots.
+                          Setting 0 will disable this rule.
+                        maximum: 36
+                        minimum: 0
+                        type: integer
+                      pointInTimeWindowHours:
+                        description: Number of hours in the past for which a point-in-time
+                          snapshot can be created.
+                        enum:
+                        - 1
+                        - 2
+                        - 3
+                        - 4
+                        - 5
+                        - 6
+                        - 7
+                        - 15
+                        - 30
+                        - 60
+                        - 90
+                        - 120
+                        - 180
+                        - 360
+                        type: integer
+                      referenceHourOfDay:
+                        description: Hour of the day to schedule snapshots using a
+                          24-hour clock, in UTC.
+                        maximum: 23
+                        minimum: 0
+                        type: integer
+                      referenceMinuteOfHour:
+                        description: Minute of the hour to schedule snapshots, in
+                          UTC.
+                        maximum: 59
+                        minimum: 0
+                        type: integer
+                      snapshotIntervalHours:
+                        description: Number of hours between snapshots.
+                        enum:
+                        - 6
+                        - 8
+                        - 12
+                        - 24
+                        type: integer
+                      snapshotRetentionDays:
+                        description: Number of days to keep recent snapshots.
+                        maximum: 365
+                        minimum: 1
+                        type: integer
+                      weeklySnapshotRetentionWeeks:
+                        description: Number of weeks to retain weekly snapshots. Setting
+                          0 will disable this rule
+                        maximum: 365
+                        minimum: 0
+                        type: integer
+                    type: object
                 type: object
               cloudManager:
                 properties:
@@ -408,6 +520,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           automationUserName:
                             type: string
                           clientCertificateSecretRef:
@@ -460,6 +573,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           servers:
                             items:
                               type: string
@@ -567,18 +681,6 @@ spec:
                           used when enabling TLS on a MongoDB resource, and not on
                           the AppDB, where TLS is configured by setting `secretRef.Name`.
                         type: boolean
-                      secretRef:
-                        description: DEPRECATED please use security.certsSecretPrefix
-                          instead SecretRef points to a Secret object containing the
-                          certificates to use when enabling TLS.
-                        properties:
-                          prefix:
-                            description: DEPRECATED please use security.certsSecretPrefix
-                              instead
-                            type: string
-                        required:
-                        - prefix
-                        type: object
                     type: object
                 type: object
               service:
@@ -753,19 +855,12 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: mongodbmulti.mongodb.com
 spec:
@@ -823,17 +918,130 @@ spec:
                 description: Backup contains configuration options for configuring
                   backup for this MongoDB resource
                 properties:
+                  assignmentLabels:
+                    description: Assignment Labels set in the Ops Manager
+                    items:
+                      type: string
+                    type: array
                   autoTerminateOnDeletion:
                     description: AutoTerminateOnDeletion indicates if the Operator
                       should stop and terminate the Backup before the cleanup, when
                       the MongoDB CR is deleted
                     type: boolean
+                  encryption:
+                    description: Encryption settings
+                    properties:
+                      kmip:
+                        description: Kmip corresponds to the KMIP configuration assigned
+                          to the Ops Manager Project's configuration.
+                        properties:
+                          client:
+                            description: KMIP Client configuration
+                            properties:
+                              clientCertificatePrefix:
+                                description: 'A prefix used to construct KMIP client
+                                  certificate (and corresponding password) Secret
+                                  names. The names are generated using the following
+                                  pattern: KMIP Client Certificate (TLS Secret): <clientCertificatePrefix>-<CR
+                                  Name>-kmip-client KMIP Client Certificate Password:
+                                  <clientCertificatePrefix>-<CR Name>-kmip-client-password
+                                  The expected key inside is called "password".'
+                                type: string
+                            type: object
+                        required:
+                        - client
+                        type: object
+                    type: object
                   mode:
                     enum:
                     - enabled
                     - disabled
                     - terminated
                     type: string
+                  snapshotSchedule:
+                    properties:
+                      clusterCheckpointIntervalMin:
+                        enum:
+                        - 15
+                        - 30
+                        - 60
+                        type: integer
+                      dailySnapshotRetentionDays:
+                        description: Number of days to retain daily snapshots. Setting
+                          0 will disable this rule.
+                        maximum: 365
+                        minimum: 0
+                        type: integer
+                      fullIncrementalDayOfWeek:
+                        description: Day of the week when Ops Manager takes a full
+                          snapshot. This ensures a recent complete backup. Ops Manager
+                          sets the default value to SUNDAY.
+                        enum:
+                        - SUNDAY
+                        - MONDAY
+                        - TUESDAY
+                        - WEDNESDAY
+                        - THURSDAY
+                        - FRIDAY
+                        - SATURDAY
+                        type: string
+                      monthlySnapshotRetentionMonths:
+                        description: Number of months to retain weekly snapshots.
+                          Setting 0 will disable this rule.
+                        maximum: 36
+                        minimum: 0
+                        type: integer
+                      pointInTimeWindowHours:
+                        description: Number of hours in the past for which a point-in-time
+                          snapshot can be created.
+                        enum:
+                        - 1
+                        - 2
+                        - 3
+                        - 4
+                        - 5
+                        - 6
+                        - 7
+                        - 15
+                        - 30
+                        - 60
+                        - 90
+                        - 120
+                        - 180
+                        - 360
+                        type: integer
+                      referenceHourOfDay:
+                        description: Hour of the day to schedule snapshots using a
+                          24-hour clock, in UTC.
+                        maximum: 23
+                        minimum: 0
+                        type: integer
+                      referenceMinuteOfHour:
+                        description: Minute of the hour to schedule snapshots, in
+                          UTC.
+                        maximum: 59
+                        minimum: 0
+                        type: integer
+                      snapshotIntervalHours:
+                        description: Number of hours between snapshots.
+                        enum:
+                        - 6
+                        - 8
+                        - 12
+                        - 24
+                        type: integer
+                      snapshotRetentionDays:
+                        description: Number of days to keep recent snapshots.
+                        maximum: 365
+                        minimum: 1
+                        type: integer
+                      weeklySnapshotRetentionWeeks:
+                        description: Number of weeks to retain weekly snapshots. Setting
+                          0 will disable this rule
+                        maximum: 365
+                        minimum: 0
+                        type: integer
+                    type: object
                 type: object
               cloudManager:
                 properties:
@@ -885,6 +1093,8 @@ spec:
                           required:
                           - spec
                           type: object
+                      required:
+                      - members
                       type: object
                     type: array
                 type: object
@@ -969,6 +1179,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           automationUserName:
                             type: string
                           clientCertificateSecretRef:
@@ -1021,6 +1232,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           servers:
                             items:
                               type: string
@@ -1128,19 +1340,19 @@ spec:
                           used when enabling TLS on a MongoDB resource, and not on
                           the AppDB, where TLS is configured by setting `secretRef.Name`.
                         type: boolean
-                      secretRef:
-                        description: DEPRECATED please use security.certsSecretPrefix
-                          instead SecretRef points to a Secret object containing the
-                          certificates to use when enabling TLS.
-                        properties:
-                          prefix:
-                            description: DEPRECATED please use security.certsSecretPrefix
-                              instead
-                            type: string
-                        required:
-                        - prefix
-                        type: object
                     type: object
+                type: object
+              statefulSet:
+                description: StatefulSetConfiguration provides the statefulset override
+                  for each of the cluster's statefulset if  "StatefulSetConfiguration"
+                  is specified at cluster level under "clusterSpecList" that takes
+                  precedence over the global one
+                properties:
+                  spec:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                required:
+                - spec
                 type: object
               type:
                 enum:
@@ -1281,19 +1493,12 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: mongodbusers.mongodb.com
 spec:
@@ -1449,19 +1654,12 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: opsmanagers.mongodb.com
 spec:
@@ -1776,6 +1974,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               automationUserName:
                                 type: string
                               clientCertificateSecretRef:
@@ -1830,6 +2029,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               servers:
                                 items:
                                   type: string
@@ -1938,18 +2138,6 @@ spec:
                               and not on the AppDB, where TLS is configured by setting
                               `secretRef.Name`.
                             type: boolean
-                          secretRef:
-                            description: DEPRECATED please use security.certsSecretPrefix
-                              instead SecretRef points to a Secret object containing
-                              the certificates to use when enabling TLS.
-                            properties:
-                              prefix:
-                                description: DEPRECATED please use security.certsSecretPrefix
-                                  instead
-                                type: string
-                            required:
-                            - prefix
-                            type: object
                         type: object
                     type: object
                   service:
@@ -1971,6 +2159,11 @@ spec:
               backup:
                 description: Backup
                 properties:
+                  assignmentLabels:
+                    description: Assignment Labels set in the Ops Manager
+                    items:
+                      type: string
+                    type: array
                   blockStores:
                     items:
                       description: DataStoreConfig is the description of the config
@@ -1978,6 +2171,11 @@ spec:
                         Optionally references the user if the Mongodb is configured
                         with authentication
                       properties:
+                        assignmentLabels:
+                          description: Assignment Labels set in the Ops Manager
+                          items:
+                            type: string
+                          type: array
                         mongodbResourceRef:
                           properties:
                             name:
@@ -2005,6 +2203,35 @@ spec:
                     description: Enabled indicates if Backups will be enabled for
                       this Ops Manager.
                     type: boolean
+                  encryption:
+                    description: Encryption settings
+                    properties:
+                      kmip:
+                        description: Kmip corresponds to the KMIP configuration assigned
+                          to the Ops Manager Project's configuration.
+                        properties:
+                          server:
+                            description: KMIP Server configuration
+                            properties:
+                              ca:
+                                description: CA corresponds to a ConfigMap containing
+                                  an entry for the CA certificate (ca.pem) used for
+                                  KMIP authentication
+                                type: string
+                              url:
+                                description: 'KMIP Server url in the following format:
+                                  hostname:port Valid examples are: 10.10.10.3:5696
+                                  my-kmip-server.mycorp.com:5696 kmip-svc.svc.cluster.local:5696'
+                                pattern: '[^\:]+:[0-9]{0,5}'
+                                type: string
+                            required:
+                            - ca
+                            - url
+                            type: object
+                        required:
+                        - server
+                        type: object
+                    type: object
                   externalServiceEnabled:
                     type: boolean
                   fileSystemStores:
@@ -2045,6 +2272,11 @@ spec:
                         Optionally references the user if the Mongodb is configured
                         with authentication
                       properties:
+                        assignmentLabels:
+                          description: Assignment Labels set in the Ops Manager
+                          items:
+                            type: string
+                          type: array
                         mongodbResourceRef:
                           properties:
                             name:
@@ -2083,6 +2315,11 @@ spec:
                       store configs used for backup.
                     items:
                       properties:
+                        assignmentLabels:
+                          description: Assignment Labels set in the Ops Manager
+                          items:
+                            type: string
+                          type: array
                         customCertificate:
                           description: Set this to "true" when you have custom certificates
                             for your S3 buckets
@@ -2136,6 +2373,11 @@ spec:
                   s3Stores:
                     items:
                       properties:
+                        assignmentLabels:
+                          description: Assignment Labels set in the Ops Manager
+                          items:
+                            type: string
+                          type: array
                         customCertificate:
                           description: Set this to "true" when you have custom certificates
                             for your S3 buckets
@@ -2465,9 +2707,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/mongodb-enterprise-openshift.yaml
+++ b/mongodb-enterprise-openshift.yaml
@@ -12,27 +12,27 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: mongodb-enterprise-operator-mongodb-webhook
 rules:
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - validatingwebhookconfigurations
-  verbs:
-  - get
-  - create
-  - update
-  - delete
+  - apiGroups:
+      - "admissionregistration.k8s.io"
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - create
+      - update
+      - delete
 
-- apiGroups:
-  - ''
-  resources:
-  - services
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - delete
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
 ---
 # Source: enterprise-operator/templates/operator-roles.yaml
 kind: ClusterRoleBinding
@@ -44,9 +44,9 @@ roleRef:
   kind: ClusterRole
   name: mongodb-enterprise-operator-mongodb-webhook
 subjects:
-- kind: ServiceAccount
-  name: mongodb-enterprise-operator
-  namespace: mongodb
+  - kind: ServiceAccount
+    name: mongodb-enterprise-operator
+    namespace: mongodb
 ---
 # Source: enterprise-operator/templates/operator-roles.yaml
 kind: Role
@@ -55,66 +55,66 @@ metadata:
   name: mongodb-enterprise-operator
   namespace: mongodb
 rules:
-- apiGroups:
-  - ''
-  resources:
-  - services
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - delete
-- apiGroups:
-  - ''
-  resources:
-  - secrets
-  - configmaps
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - delete
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - delete
-  - update
-- apiGroups:
-  - ''
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-  - delete
-  - deletecollection
-- apiGroups:
-  - mongodb.com
-  verbs:
-  - '*'
-  resources:
-  - mongodb
-  - mongodb/finalizers
-  - mongodbusers
-  - opsmanagers
-  - opsmanagers/finalizers
-  - mongodbmulti
-  - mongodbmulti/finalizers
-  - mongodb/status
-  - mongodbusers/status
-  - opsmanagers/status
-  - mongodbmulti/status
+  - apiGroups:
+      - ''
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+      - configmaps
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - delete
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - deletecollection
+  - apiGroups:
+      - mongodb.com
+    verbs:
+      - '*'
+    resources:
+      - mongodb
+      - mongodb/finalizers
+      - mongodbusers
+      - opsmanagers
+      - opsmanagers/finalizers
+      - mongodbmulti
+      - mongodbmulti/finalizers
+      - mongodb/status
+      - mongodbusers/status
+      - opsmanagers/status
+      - mongodbmulti/status
 
 # This ClusterRoleBinding is necessary in order to use validating
 # webhooks—these will prevent you from applying a variety of invalid resource
@@ -132,9 +132,9 @@ roleRef:
   kind: Role
   name: mongodb-enterprise-operator
 subjects:
-- kind: ServiceAccount
-  name: mongodb-enterprise-operator
-  namespace: mongodb
+  - kind: ServiceAccount
+    name: mongodb-enterprise-operator
+    namespace: mongodb
 ---
 # Source: enterprise-operator/templates/database-roles.yaml
 apiVersion: v1
@@ -164,20 +164,20 @@ metadata:
   name: mongodb-enterprise-appdb
   namespace: mongodb
 rules:
-- apiGroups:
-  - ''
-  resources:
-  - secrets
-  verbs:
-  - get
-- apiGroups:
-  - ''
-  resources:
-  - pods
-  verbs:
-  - patch
-  - delete
-  - get
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - patch
+      - delete
+      - get
 ---
 # Source: enterprise-operator/templates/database-roles.yaml
 kind: RoleBinding
@@ -190,9 +190,9 @@ roleRef:
   kind: Role
   name: mongodb-enterprise-appdb
 subjects:
-- kind: ServiceAccount
-  name: mongodb-enterprise-appdb
-  namespace: mongodb
+  - kind: ServiceAccount
+    name: mongodb-enterprise-appdb
+    namespace: mongodb
 ---
 # Source: enterprise-operator/templates/operator.yaml
 apiVersion: apps/v1
@@ -216,137 +216,139 @@ spec:
     spec:
       serviceAccountName: mongodb-enterprise-operator
       containers:
-      - name: mongodb-enterprise-operator
-        image: quay.io/mongodb/mongodb-enterprise-operator-ubi:1.17.2
-        imagePullPolicy: Always
-        args:
-        - -watch-resource=mongodb
-        - -watch-resource=opsmanagers
-        - -watch-resource=mongodbusers
-        command:
-        - /usr/local/bin/mongodb-enterprise-operator
-        resources:
-          limits:
-            cpu: 1100m
-            memory: 1Gi
-          requests:
-            cpu: 500m
-            memory: 200Mi
-        env:
-        - name: OPERATOR_ENV
-          value: prod
-        - name: WATCH_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: CURRENT_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: MANAGED_SECURITY_CONTEXT
-          value: 'true'
-        - name: IMAGE_PULL_POLICY
-          value: Always
+        - name: mongodb-enterprise-operator
+          image: "quay.io/mongodb/mongodb-enterprise-operator-ubi:1.18.0"
+          imagePullPolicy: Always
+          args:
+            - -watch-resource=mongodb
+            - -watch-resource=opsmanagers
+            - -watch-resource=mongodbusers
+          command:
+            - /usr/local/bin/mongodb-enterprise-operator
+          resources:
+            limits:
+              cpu: 1100m
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 200Mi
+          env:
+            - name: OPERATOR_ENV
+              value: prod
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CURRENT_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MANAGED_SECURITY_CONTEXT
+              value: 'true'
+            - name: CLUSTER_CLIENT_TIMEOUT
+              value: "10"
+            - name: IMAGE_PULL_POLICY
+              value: Always
         # Database
-        - name: MONGODB_ENTERPRISE_DATABASE_IMAGE
-          value: quay.io/mongodb/mongodb-enterprise-database-ubi
-        - name: INIT_DATABASE_IMAGE_REPOSITORY
-          value: quay.io/mongodb/mongodb-enterprise-init-database-ubi
-        - name: INIT_DATABASE_VERSION
-          value: 1.0.13
-        - name: DATABASE_VERSION
-          value: 2.0.2
+            - name: MONGODB_ENTERPRISE_DATABASE_IMAGE
+              value: quay.io/mongodb/mongodb-enterprise-database-ubi
+            - name: INIT_DATABASE_IMAGE_REPOSITORY
+              value: quay.io/mongodb/mongodb-enterprise-init-database-ubi
+            - name: INIT_DATABASE_VERSION
+              value: 1.0.14
+            - name: DATABASE_VERSION
+              value: 2.0.2
         # Ops Manager
-        - name: OPS_MANAGER_IMAGE_REPOSITORY
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
-        - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
-          value: quay.io/mongodb/mongodb-enterprise-init-ops-manager-ubi
-        - name: INIT_OPS_MANAGER_VERSION
-          value: 1.0.9
+            - name: OPS_MANAGER_IMAGE_REPOSITORY
+              value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi
+            - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
+              value: quay.io/mongodb/mongodb-enterprise-init-ops-manager-ubi
+            - name: INIT_OPS_MANAGER_VERSION
+              value: 1.0.10
         # AppDB
-        - name: INIT_APPDB_IMAGE_REPOSITORY
-          value: quay.io/mongodb/mongodb-enterprise-init-appdb-ubi
-        - name: INIT_APPDB_VERSION
-          value: 1.0.13
-        - name: OPS_MANAGER_IMAGE_PULL_POLICY
-          value: Always
-        - name: AGENT_IMAGE
-          value: quay.io/mongodb/mongodb-agent-ubi:11.12.0.7388-1
-        - name: MONGODB_IMAGE
-          value: mongodb-enterprise-appdb-database-ubi
-        - name: MONGODB_REPO_URL
-          value: quay.io/mongodb
-        - name: PERFORM_FAILOVER
-          value: 'true'
-        - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_2_0_2
-          value: quay.io/mongodb/mongodb-enterprise-database-ubi:2.0.2
-        - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_0_13
-          value: quay.io/mongodb/mongodb-enterprise-init-database-ubi:1.0.13
-        - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_0_9
-          value: quay.io/mongodb/mongodb-enterprise-init-ops-manager-ubi:1.0.9
-        - name: RELATED_IMAGE_INIT_APPDB_IMAGE_REPOSITORY_1_0_13
-          value: quay.io/mongodb/mongodb-enterprise-init-appdb-ubi:1.0.13
-        - name: RELATED_IMAGE_AGENT_IMAGE_11_0_5_6963_1
-          value: quay.io/mongodb/mongodb-agent-ubi:11.0.5.6963-1
-        - name: RELATED_IMAGE_AGENT_IMAGE_11_12_0_7388_1
-          value: quay.io/mongodb/mongodb-agent-ubi:11.12.0.7388-1
-        - name: RELATED_IMAGE_AGENT_IMAGE_12_0_4_7554_1
-          value: quay.io/mongodb/mongodb-agent-ubi:12.0.4.7554-1
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_0
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.0
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_1
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.1
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_2
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.2
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_3
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.3
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_4
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.4
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_5
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.5
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_6
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.6
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_7
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.7
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_8
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.8
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_9
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.9
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_10
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.10
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_11
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.11
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_12
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.12
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_13
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.13
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_14
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.14
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_15
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.15
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_6_0_0
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:6.0.0
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_6_0_1
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:6.0.1
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_6_0_2
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:6.0.2
-        - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_6_0_3
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:6.0.3
-        - name: RELATED_IMAGE_MONGODB_IMAGE_4_2_11_ent
-          value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.2.11-ent
-        - name: RELATED_IMAGE_MONGODB_IMAGE_4_2_2_ent
-          value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.2.2-ent
-        - name: RELATED_IMAGE_MONGODB_IMAGE_4_2_6_ent
-          value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.2.6-ent
-        - name: RELATED_IMAGE_MONGODB_IMAGE_4_2_8_ent
-          value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.2.8-ent
-        - name: RELATED_IMAGE_MONGODB_IMAGE_4_4_0_ent
-          value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.4.0-ent
-        - name: RELATED_IMAGE_MONGODB_IMAGE_4_4_11_ent
-          value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.4.11-ent
-        - name: RELATED_IMAGE_MONGODB_IMAGE_4_4_4_ent
-          value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.4.4-ent
-        - name: RELATED_IMAGE_MONGODB_IMAGE_5_0_1_ent
-          value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:5.0.1-ent
-        - name: RELATED_IMAGE_MONGODB_IMAGE_5_0_5_ent
-          value: quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:5.0.5-ent
+            - name: INIT_APPDB_IMAGE_REPOSITORY
+              value: quay.io/mongodb/mongodb-enterprise-init-appdb-ubi
+            - name: INIT_APPDB_VERSION
+              value: 1.0.14
+            - name: OPS_MANAGER_IMAGE_PULL_POLICY
+              value: Always
+            - name: AGENT_IMAGE
+              value: "quay.io/mongodb/mongodb-agent-ubi:12.0.15.7646-1"
+            - name: MONGODB_IMAGE
+              value: mongodb-enterprise-appdb-database-ubi
+            - name: MONGODB_REPO_URL
+              value: quay.io/mongodb
+            - name: PERFORM_FAILOVER
+              value: 'true'
+            - name: RELATED_IMAGE_MONGODB_ENTERPRISE_DATABASE_IMAGE_2_0_2
+              value: "quay.io/mongodb/mongodb-enterprise-database-ubi:2.0.2"
+            - name: RELATED_IMAGE_INIT_DATABASE_IMAGE_REPOSITORY_1_0_14
+              value: "quay.io/mongodb/mongodb-enterprise-init-database-ubi:1.0.14"
+            - name: RELATED_IMAGE_INIT_OPS_MANAGER_IMAGE_REPOSITORY_1_0_10
+              value: "quay.io/mongodb/mongodb-enterprise-init-ops-manager-ubi:1.0.10"
+            - name: RELATED_IMAGE_INIT_APPDB_IMAGE_REPOSITORY_1_0_14
+              value: "quay.io/mongodb/mongodb-enterprise-init-appdb-ubi:1.0.14"
+            - name: RELATED_IMAGE_AGENT_IMAGE_11_0_5_6963_1
+              value: "quay.io/mongodb/mongodb-agent-ubi:11.0.5.6963-1"
+            - name: RELATED_IMAGE_AGENT_IMAGE_11_12_0_7388_1
+              value: "quay.io/mongodb/mongodb-agent-ubi:11.12.0.7388-1"
+            - name: RELATED_IMAGE_AGENT_IMAGE_12_0_4_7554_1
+              value: "quay.io/mongodb/mongodb-agent-ubi:12.0.4.7554-1"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_0
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.0"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_1
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.1"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_2
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.2"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_3
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.3"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_4
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.4"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_5
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.5"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_6
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.6"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_7
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.7"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_8
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.8"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_9
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.9"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_10
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.10"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_11
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.11"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_12
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.12"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_13
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.13"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_14
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.14"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_5_0_15
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:5.0.15"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_6_0_0
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:6.0.0"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_6_0_1
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:6.0.1"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_6_0_2
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:6.0.2"
+            - name: RELATED_IMAGE_OPS_MANAGER_IMAGE_REPOSITORY_6_0_3
+              value: "quay.io/mongodb/mongodb-enterprise-ops-manager-ubi:6.0.3"
+            - name: RELATED_IMAGE_MONGODB_IMAGE_4_2_11_ent
+              value: "quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.2.11-ent"
+            - name: RELATED_IMAGE_MONGODB_IMAGE_4_2_2_ent
+              value: "quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.2.2-ent"
+            - name: RELATED_IMAGE_MONGODB_IMAGE_4_2_6_ent
+              value: "quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.2.6-ent"
+            - name: RELATED_IMAGE_MONGODB_IMAGE_4_2_8_ent
+              value: "quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.2.8-ent"
+            - name: RELATED_IMAGE_MONGODB_IMAGE_4_4_0_ent
+              value: "quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.4.0-ent"
+            - name: RELATED_IMAGE_MONGODB_IMAGE_4_4_11_ent
+              value: "quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.4.11-ent"
+            - name: RELATED_IMAGE_MONGODB_IMAGE_4_4_4_ent
+              value: "quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:4.4.4-ent"
+            - name: RELATED_IMAGE_MONGODB_IMAGE_5_0_1_ent
+              value: "quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:5.0.1-ent"
+            - name: RELATED_IMAGE_MONGODB_IMAGE_5_0_5_ent
+              value: "quay.io/mongodb/mongodb-enterprise-appdb-database-ubi:5.0.5-ent"

--- a/mongodb-enterprise.yaml
+++ b/mongodb-enterprise.yaml
@@ -12,27 +12,27 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: mongodb-enterprise-operator-mongodb-webhook
 rules:
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - validatingwebhookconfigurations
-  verbs:
-  - get
-  - create
-  - update
-  - delete
+  - apiGroups:
+      - "admissionregistration.k8s.io"
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - create
+      - update
+      - delete
 
-- apiGroups:
-  - ''
-  resources:
-  - services
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - delete
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
 ---
 # Source: enterprise-operator/templates/operator-roles.yaml
 kind: ClusterRoleBinding
@@ -44,9 +44,9 @@ roleRef:
   kind: ClusterRole
   name: mongodb-enterprise-operator-mongodb-webhook
 subjects:
-- kind: ServiceAccount
-  name: mongodb-enterprise-operator
-  namespace: mongodb
+  - kind: ServiceAccount
+    name: mongodb-enterprise-operator
+    namespace: mongodb
 ---
 # Source: enterprise-operator/templates/operator-roles.yaml
 kind: Role
@@ -55,66 +55,66 @@ metadata:
   name: mongodb-enterprise-operator
   namespace: mongodb
 rules:
-- apiGroups:
-  - ''
-  resources:
-  - services
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - delete
-- apiGroups:
-  - ''
-  resources:
-  - secrets
-  - configmaps
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - delete
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - delete
-  - update
-- apiGroups:
-  - ''
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-  - delete
-  - deletecollection
-- apiGroups:
-  - mongodb.com
-  verbs:
-  - '*'
-  resources:
-  - mongodb
-  - mongodb/finalizers
-  - mongodbusers
-  - opsmanagers
-  - opsmanagers/finalizers
-  - mongodbmulti
-  - mongodbmulti/finalizers
-  - mongodb/status
-  - mongodbusers/status
-  - opsmanagers/status
-  - mongodbmulti/status
+  - apiGroups:
+      - ''
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+      - configmaps
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - delete
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - deletecollection
+  - apiGroups:
+      - mongodb.com
+    verbs:
+      - '*'
+    resources:
+      - mongodb
+      - mongodb/finalizers
+      - mongodbusers
+      - opsmanagers
+      - opsmanagers/finalizers
+      - mongodbmulti
+      - mongodbmulti/finalizers
+      - mongodb/status
+      - mongodbusers/status
+      - opsmanagers/status
+      - mongodbmulti/status
 
 # This ClusterRoleBinding is necessary in order to use validating
 # webhooks—these will prevent you from applying a variety of invalid resource
@@ -132,9 +132,9 @@ roleRef:
   kind: Role
   name: mongodb-enterprise-operator
 subjects:
-- kind: ServiceAccount
-  name: mongodb-enterprise-operator
-  namespace: mongodb
+  - kind: ServiceAccount
+    name: mongodb-enterprise-operator
+    namespace: mongodb
 ---
 # Source: enterprise-operator/templates/database-roles.yaml
 apiVersion: v1
@@ -164,20 +164,20 @@ metadata:
   name: mongodb-enterprise-appdb
   namespace: mongodb
 rules:
-- apiGroups:
-  - ''
-  resources:
-  - secrets
-  verbs:
-  - get
-- apiGroups:
-  - ''
-  resources:
-  - pods
-  verbs:
-  - patch
-  - delete
-  - get
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - patch
+      - delete
+      - get
 ---
 # Source: enterprise-operator/templates/database-roles.yaml
 kind: RoleBinding
@@ -190,9 +190,9 @@ roleRef:
   kind: Role
   name: mongodb-enterprise-appdb
 subjects:
-- kind: ServiceAccount
-  name: mongodb-enterprise-appdb
-  namespace: mongodb
+  - kind: ServiceAccount
+    name: mongodb-enterprise-appdb
+    namespace: mongodb
 ---
 # Source: enterprise-operator/templates/operator.yaml
 apiVersion: apps/v1
@@ -219,63 +219,65 @@ spec:
         runAsNonRoot: true
         runAsUser: 2000
       containers:
-      - name: mongodb-enterprise-operator
-        image: quay.io/mongodb/mongodb-enterprise-operator:1.17.2
-        imagePullPolicy: Always
-        args:
-        - -watch-resource=mongodb
-        - -watch-resource=opsmanagers
-        - -watch-resource=mongodbusers
-        command:
-        - /usr/local/bin/mongodb-enterprise-operator
-        resources:
-          limits:
-            cpu: 1100m
-            memory: 1Gi
-          requests:
-            cpu: 500m
-            memory: 200Mi
-        env:
-        - name: OPERATOR_ENV
-          value: prod
-        - name: WATCH_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: CURRENT_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: IMAGE_PULL_POLICY
-          value: Always
+        - name: mongodb-enterprise-operator
+          image: "quay.io/mongodb/mongodb-enterprise-operator:1.18.0"
+          imagePullPolicy: Always
+          args:
+            - -watch-resource=mongodb
+            - -watch-resource=opsmanagers
+            - -watch-resource=mongodbusers
+          command:
+            - /usr/local/bin/mongodb-enterprise-operator
+          resources:
+            limits:
+              cpu: 1100m
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 200Mi
+          env:
+            - name: OPERATOR_ENV
+              value: prod
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CURRENT_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CLUSTER_CLIENT_TIMEOUT
+              value: "10"
+            - name: IMAGE_PULL_POLICY
+              value: Always
         # Database
-        - name: MONGODB_ENTERPRISE_DATABASE_IMAGE
-          value: quay.io/mongodb/mongodb-enterprise-database
-        - name: INIT_DATABASE_IMAGE_REPOSITORY
-          value: quay.io/mongodb/mongodb-enterprise-init-database
-        - name: INIT_DATABASE_VERSION
-          value: 1.0.13
-        - name: DATABASE_VERSION
-          value: 2.0.2
+            - name: MONGODB_ENTERPRISE_DATABASE_IMAGE
+              value: quay.io/mongodb/mongodb-enterprise-database
+            - name: INIT_DATABASE_IMAGE_REPOSITORY
+              value: quay.io/mongodb/mongodb-enterprise-init-database
+            - name: INIT_DATABASE_VERSION
+              value: 1.0.14
+            - name: DATABASE_VERSION
+              value: 2.0.2
         # Ops Manager
-        - name: OPS_MANAGER_IMAGE_REPOSITORY
-          value: quay.io/mongodb/mongodb-enterprise-ops-manager
-        - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
-          value: quay.io/mongodb/mongodb-enterprise-init-ops-manager
-        - name: INIT_OPS_MANAGER_VERSION
-          value: 1.0.9
+            - name: OPS_MANAGER_IMAGE_REPOSITORY
+              value: quay.io/mongodb/mongodb-enterprise-ops-manager
+            - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
+              value: quay.io/mongodb/mongodb-enterprise-init-ops-manager
+            - name: INIT_OPS_MANAGER_VERSION
+              value: 1.0.10
         # AppDB
-        - name: INIT_APPDB_IMAGE_REPOSITORY
-          value: quay.io/mongodb/mongodb-enterprise-init-appdb
-        - name: INIT_APPDB_VERSION
-          value: 1.0.13
-        - name: OPS_MANAGER_IMAGE_PULL_POLICY
-          value: Always
-        - name: AGENT_IMAGE
-          value: quay.io/mongodb/mongodb-agent:11.12.0.7388-1
-        - name: MONGODB_IMAGE
-          value: mongodb-enterprise-appdb-database
-        - name: MONGODB_REPO_URL
-          value: quay.io/mongodb
-        - name: PERFORM_FAILOVER
-          value: 'true'
+            - name: INIT_APPDB_IMAGE_REPOSITORY
+              value: quay.io/mongodb/mongodb-enterprise-init-appdb
+            - name: INIT_APPDB_VERSION
+              value: 1.0.14
+            - name: OPS_MANAGER_IMAGE_PULL_POLICY
+              value: Always
+            - name: AGENT_IMAGE
+              value: "quay.io/mongodb/mongodb-agent:12.0.15.7646-1"
+            - name: MONGODB_IMAGE
+              value: mongodb-enterprise-appdb-database
+            - name: MONGODB_REPO_URL
+              value: quay.io/mongodb
+            - name: PERFORM_FAILOVER
+              value: 'true'

--- a/samples/mongodb/minimal/sharded-cluster.yaml
+++ b/samples/mongodb/minimal/sharded-cluster.yaml
@@ -31,7 +31,7 @@ spec:
 
   configSrvPodSpec:
     podTemplate:
-      spec:        
+      spec:
         containers:
           - name: mongodb-enterprise-database
             resources:
@@ -43,7 +43,7 @@ spec:
                 memory: 500M
   shardPodSpec:
     podTemplate:
-      spec:        
+      spec:
         containers:
           - name: mongodb-enterprise-database
             resources:
@@ -56,7 +56,7 @@ spec:
 
   mongosPodSpec:
     podTemplate:
-      spec:        
+      spec:
         containers:
           - name: mongodb-enterprise-database
             resources:

--- a/tools/multicluster/go.mod
+++ b/tools/multicluster/go.mod
@@ -1,6 +1,6 @@
 module github.com/10gen/ops-manager-kubernetes/multi
 
-go 1.18
+go 1.19
 
 require (
 	github.com/ghodss/yaml v1.0.0

--- a/tools/multicluster/main.go
+++ b/tools/multicluster/main.go
@@ -1116,18 +1116,18 @@ func copyDatabaseRoles(ctx context.Context, src, dst kubernetes.Interface, names
 	}
 	if len(appdbSA.ImagePullSecrets) > 0 {
 		if err := copySecret(ctx, src, dst, namespace, appdbSA.ImagePullSecrets[0].Name); err != nil {
-			errorChan <- fmt.Errorf("failed creating image pull secret %s: %s", appdbSA.ImagePullSecrets[0].Name, err)
+			fmt.Printf("failed creating image pull secret %s: %s\n", appdbSA.ImagePullSecrets[0].Name, err)
 		}
 
 	}
 	if len(dbpodsSA.ImagePullSecrets) > 0 {
 		if err := copySecret(ctx, src, dst, namespace, dbpodsSA.ImagePullSecrets[0].Name); err != nil {
-			errorChan <- fmt.Errorf("failed creating image pull secret %s: %s", dbpodsSA.ImagePullSecrets[0].Name, err)
+			fmt.Printf("failed creating image pull secret %s: %s\n", dbpodsSA.ImagePullSecrets[0].Name, err)
 		}
 	}
 	if len(opsManagerSA.ImagePullSecrets) > 0 {
 		if err := copySecret(ctx, src, dst, namespace, opsManagerSA.ImagePullSecrets[0].Name); err != nil {
-			errorChan <- fmt.Errorf("failed creating image pull secret %s: %s", opsManagerSA.ImagePullSecrets[0].Name, err)
+			fmt.Printf("failed creating image pull secret %s: %s\n", opsManagerSA.ImagePullSecrets[0].Name, err)
 		}
 	}
 	_, err = dst.CoreV1().ServiceAccounts(namespace).Create(ctx, &corev1.ServiceAccount{


### PR DESCRIPTION
## Kubernetes Enterprise Operator Release 1.18.0


This release patch has been created and it should be reviewed now.


You can add new commits to this patch if needed. After changes have
been reviewed, merge this PR for PCT to continue the release process.