### PR TITLE
update spec.template.spec.containers.image to use ubi image

### DIFF
--- a/mongodb-enterprise.yaml
+++ b/mongodb-enterprise.yaml
@@ -219,7 +219,7 @@ spec:
         runAsUser: 2000
       containers:
         - name: mongodb-enterprise-operator
-          image: "quay.io/mongodb/mongodb-enterprise-operator:1.20.1"
+          image: "quay.io/mongodb/mongodb-enterprise-operator-ubi:1.20.1"
           imagePullPolicy: Always
           args:
             - -watch-resource=mongodb


### PR DESCRIPTION
Update the image for mongodb-enterprise-operator to use quay.io/mongodb/mongodb-enterprise-operator-ubi

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

