### PR TITLE
fix broken link to OpenShift installation description

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ CRDs are defined cluster-wide, so to install them, you must have Cluster-level a
 
 #### Operator Installation
 
-> In order to install the Operator in OpenShift, please follow [these](openshift-install.md) instructions instead.
+> In order to install the Operator in OpenShift, please follow [these](docs/openshift-marketplace.md) instructions instead.
 
 To install the Operator using yaml files, you may apply the config directly from github;
 


### PR DESCRIPTION
The current link in this document points to openshift-install.md which was removed in pull #238 

commit 366c8b2e8b278233a2fc5909e3031c5418c6e624
Author: Rajdeep Das <rajdeep.das@mongodb.com>
Date:   Mon Jan 30 14:15:48 2023 +0100

The correct document appears to be docs/openshift-marketplace.md

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
  no, there doesn't appear to be issues in this repo
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
no, not yet
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
  -> is this applicable to this repo?

