### PR TITLE
add mac build - notarizing

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1,0 +1,81 @@
+variables:
+
+functions:
+
+  "clone":
+    - command: subprocess.exec
+      type: setup
+      params:
+        command: "mkdir -p src/github.com/mongodb"
+    - command: git.get_project
+      type: setup
+      params:
+        directory: src/github.com/mongodb/mongodb-enterprise-kubernetes
+
+  "install goreleaser":
+    - command: shell.exec
+      type: setup
+      include_expansions_in_env:
+        - goreleaser_pro_tar_gz
+      params:
+        script: |
+          set -Eeu pipefail
+          
+          curl -fL "${goreleaser_pro_tar_gz}" --output goreleaser_Linux_x86_64.tar.gz
+          tar -xf goreleaser_Linux_x86_64.tar.gz
+          chmod 755 ./goreleaser
+
+  "install macos notarization service":
+    - command: shell.exec
+      type: setup
+      params:
+        include_expansions_in_env:
+          - notary_service_url
+        script: |
+          set -Eeu pipefail
+          
+          curl "${notary_service_url}" --output macos-notary.zip
+          unzip -u macos-notary.zip
+          chmod 755 ./linux_amd64/macnotary
+  "release":
+    - command: shell.exec
+      type: setup
+      params:
+        working_dir: src/github.com/mongodb/mongodb-enterprise-kubernetes/tools/multicluster
+        add_to_path:
+          - src/github.com/mongodb/tools
+          - src/github.com/mongodb/tools/linux_amd64
+        include_expansions_in_env:
+          - GITHUB_TOKEN
+          - macos_notary_keyid
+          - macos_notary_secret
+          - workdir
+        env:
+          MACOS_NOTARY_KEY: ${macos_notary_keyid}
+          MACOS_NOTARY_SECRET: ${macos_notary_secret}
+        script: |
+          set -Eeu pipefail
+          
+          ${workdir}/goreleaser release
+
+tasks:
+  - name: package_goreleaser
+    tags: ["packaging"]
+    commands:
+      - func: "clone"
+      - func: "install goreleaser"
+      - func: "install macos notarization service"
+      - func: "release"
+
+buildvariants:
+
+# This variant is kept manual for now in order avoid any interfering with the existing release process.
+# In the future, it will be called in one of two ways:
+# By PCT when a new operator version is released.
+# When a new tag is out similarly to github actions.
+- name: release_mcli
+  display_name: Release Go multi-cluster binary
+  run_on:
+    - ubuntu2204-small
+  tasks:
+    - name: package_goreleaser

--- a/tools/multicluster/.goreleaser.yaml
+++ b/tools/multicluster/.goreleaser.yaml
@@ -14,6 +14,11 @@ builds:
     - amd64
     - arm64
 
+    hooks:
+      # This will notarize Apple binaries and replace goreleaser bins with the notarized ones
+      post:
+        - cmd: ./kubectl_mac_notarize.sh
+          output: true
 
 archives:
   - format: tar.gz

--- a/tools/multicluster/kubectl_mac_notarize.sh
+++ b/tools/multicluster/kubectl_mac_notarize.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 MongoDB Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeou pipefail
+
+# Notarize generated binaries with Apple and replace the original binary with the notarized one
+# This depends on binaries being generated in a goreleaser manner and gon being set up.
+# goreleaser should already take care of calling this script as a hook.
+
+if [[ -f "./dist/kubectl-mongodb_darwin_arm64/kubectl-mongodb" && -f "./dist/kubectl-mongodb_darwin_amd64_v1/kubectl-mongodb" && ! -f "./dist/kubectl-mongodb_macos_signed.zip" ]]; then
+	echo "notarizing macOs binaries"
+	zip -r ./dist/kubectl-mongodb_amd64_arm64_bin.zip ./dist/kubectl-mongodb_darwin_amd64_v1/kubectl-mongodb ./dist/kubectl-mongodb_darwin_arm64/kubectl-mongodb # The Notarization Service takes an archive as input
+	"${workdir-}"/macnotary \
+		-f ./dist/kubectl-mongodb_amd64_arm64_bin.zip \
+		-m notarizeAndSign -u https://dev.macos-notary.build.10gen.cc/api \
+		-b com.mongodb.mongodb-kubectl-mongodb \
+		-o ./dist/kubectl-mongodb_macos_signed.zip
+
+	echo "replacing original files"
+	unzip -oj ./dist/kubectl-mongodb_macos_signed.zip dist/macos_darwin_amd64_v1/kubectl-mongodb -d ./dist/macos_darwin_amd64_v1/
+	unzip -oj ./dist/kubectl-mongodb_macos_signed.zip dist/macos_darwin_arm64/kubectl-mongodb -d ./dist/macos_darwin_arm64/
+fi


### PR DESCRIPTION
### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

### Summary

- add the base code to notarize our multi-cluster binary via goreleaser and a notarizing hook
- notarizing is done via evergreen instead of github actions due to security reasons 
- the idea is the following 
  - have a release
  - merge that release
  - have evergreen pick that up
  - install all the binaries (goreleaser, notarizer)
  - goreleaser releases the binaries and the hook replaces them with notarized ones


run the build manually: 
```
 evergreen patch -p mongodb-enterprise-kubernetes  -v release_mcli -t all -y -f -y --browse
```
