### PR TITLE
make script executable and add ignored folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 *.iml
 .DS_Store
+tools/multicluster/linux_amd64/*

--- a/tools/multicluster/kubectl_mac_notarize.sh
+++ b/tools/multicluster/kubectl_mac_notarize.sh
@@ -23,7 +23,7 @@ set -Eeou pipefail
 if [[ -f "./dist/kubectl-mongodb_darwin_arm64/kubectl-mongodb" && -f "./dist/kubectl-mongodb_darwin_amd64_v1/kubectl-mongodb" && ! -f "./dist/kubectl-mongodb_macos_signed.zip" ]]; then
 	echo "notarizing macOs binaries"
 	zip -r ./dist/kubectl-mongodb_amd64_arm64_bin.zip ./dist/kubectl-mongodb_darwin_amd64_v1/kubectl-mongodb ./dist/kubectl-mongodb_darwin_arm64/kubectl-mongodb # The Notarization Service takes an archive as input
-	"${workdir-}"/macnotary \
+	"${workdir:-.}"/linux_amd64/macnotary \
 		-f ./dist/kubectl-mongodb_amd64_arm64_bin.zip \
 		-m notarizeAndSign -u https://dev.macos-notary.build.10gen.cc/api \
 		-b com.mongodb.mongodb-kubectl-mongodb \


### PR DESCRIPTION
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

### Summary
- During local testing I realized that paths were wrong and the script was not execuable
- Additionally adding the file under .gitignore enables local testing 


This is as far as I can get without a local notarizing key and secret:
```
1.21.3 ~/projects/mongodb-enterprise-kubernetes/tools/multicluster appdb-version*                                                                                                             03:34:51 PM
❯ GITHUB_TOKEN=<abc> goreleaser release --snapshot
  • starting release...
  • loading                                          path=.goreleaser.yaml
  • skipping announce, publish and validate...
  • loading environment variables
    • using token from  $GITHUB_TOKEN 
  • getting and validating git state
    • git state                                      commit=45e9b120f889128efbf32ccb507a9bfdcf8484cd branch=appdb-version current_tag=1.25.0-test previous_tag=1.21.0-mcli dirty=true
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=1.25.0-next
  • running before hooks
    • running                                        hook=go mod tidy
  • checking distribution directory
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/kubectl-mongodb_darwin_arm64/kubectl-mongodb
    • building                                       binary=dist/kubectl-mongodb_darwin_amd64_v1/kubectl-mongodb
    • building                                       binary=dist/kubectl-mongodb_linux_amd64_v1/kubectl-mongodb
    • building                                       binary=dist/kubectl-mongodb_linux_arm64/kubectl-mongodb
    • running hook                                   hook=./kubectl_mac_notarize.sh
    • running hook                                   hook=./kubectl_mac_notarize.sh
notarizing macOs binaries
  adding: dist/kubectl-mongodb_darwin_amd64_v1/kubectl-mongodb    • running hook                                   hook=./kubectl_mac_notarize.sh
notarizing macOs binaries
  adding: dist/kubectl-mongodb_darwin_amd64_v1/kubectl-mongodb    • running hook                                   hook=./kubectl_mac_notarize.sh
notarizing macOs binaries
  adding: dist/kubectl-mongodb_darwin_amd64_v1/kubectl-mongodb (deflated 72%)
  adding: dist/kubectl-mongodb_darwin_arm64/kubectl-mongodb (deflated 72%)
  adding: dist/kubectl-mongodb_darwin_arm64/kubectl-mongodb (deflated 72%)
  adding: dist/kubectl-mongodb_darwin_arm64/kubectl-mongodb (deflated 73%)
Version=3.8.2
Running macos notary client with following configuration. Use -h flag to get more info about the command
inputFile: ./dist/kubectl-mongodb_amd64_arm64_bin.zip
url: https://dev.macos-notary.build.10gen.cc/api
bundleId: com.mongodb.mongodb-kubectl-mongodb
mode: notarizeAndSign
secret: *****
keyId: 
outPath: ./dist/kubectl-mongodb_macos_signed.zip
entitlementsFile: 
artifactType: binary
taskId: 
taskComment: 
artifactType: binary
verify: false
timeoutMinutes 15
----------------------------
 (deflated 73%)
Version=3.8.2
Running macos notary client with following configuration. Use -h flag to get more info about the command
inputFile: ./dist/kubectl-mongodb_amd64_arm64_bin.zip
url: https://dev.macos-notary.build.10gen.cc/api
bundleId: com.mongodb.mongodb-kubectl-mongodb
mode: notarizeAndSign
secret: *****
keyId: 
outPath: ./dist/kubectl-mongodb_macos_signed.zip
entitlementsFile: 
artifactType: binary
taskId: 
taskComment: 
artifactType: binary
verify: false
timeoutMinutes 15
----------------------------
 (deflated 73%)
Version=3.8.2
Running macos notary client with following configuration. Use -h flag to get more info about the command
inputFile: ./dist/kubectl-mongodb_amd64_arm64_bin.zip
url: https://dev.macos-notary.build.10gen.cc/api
bundleId: com.mongodb.mongodb-kubectl-mongodb
mode: notarizeAndSign
secret: *****
keyId: 
outPath: ./dist/kubectl-mongodb_macos_signed.zip
entitlementsFile: 
artifactType: binary
taskId: 
taskComment: 
artifactType: binary
verify: false
timeoutMinutes 15
----------------------------
warning: failed to check the Apple's Notary Service status Get "https://dev.macos-notary.build.10gen.cc/api/status/appleNotaryService": dial tcp 3.231.142.233:443: i/o timeout
getting upload url
warning: failed to check the Apple's Notary Service status Get "https://dev.macos-notary.build.10gen.cc/api/status/appleNotaryService": dial tcp 3.231.142.233:443: i/o timeout
getting upload url
warning: failed to check the Apple's Notary Service status Get "https://dev.macos-notary.build.10gen.cc/api/status/appleNotaryService": dial tcp 3.231.142.233:443: i/o timeout
getting upload url
Get "https://dev.macos-notary.build.10gen.cc/api/uploadurl": dial tcp 3.231.142.233:443: i/o timeout
Get "https://dev.macos-notary.build.10gen.cc/api/uploadurl": dial tcp 3.231.142.233:443: i/o timeout
Get "https://dev.macos-notary.build.10gen.cc/api/uploadurl": dial tcp 3.231.142.233:443: i/o timeout
    • took: 1m5s
  ⨯ release failed after 1m5s                error=post hook failed: shell: './kubectl_mac_notarize.sh': exit status 1: notarizing macOs binaries
  adding: dist/kubectl-mongodb_darwin_amd64_v1/kubectl-mongodb (deflated 72%)
  adding: dist/kubectl-mongodb_darwin_arm64/kubectl-mongodb (deflated 73%)
Version=3.8.2
Running macos notary client with following configuration. Use -h flag to get more info about the command
inputFile: ./dist/kubectl-mongodb_amd64_arm64_bin.zip
url: https://dev.macos-notary.build.10gen.cc/api
bundleId: com.mongodb.mongodb-kubectl-mongodb
mode: notarizeAndSign
secret: *****
keyId: 
outPath: ./dist/kubectl-mongodb_macos_signed.zip
entitlementsFile: 
artifactType: binary
taskId: 
taskComment: 
artifactType: binary
verify: false
timeoutMinutes 15
----------------------------
warning: failed to check the Apple's Notary Service status Get "https://dev.macos-notary.build.10gen.cc/api/status/appleNotaryService": dial tcp 3.231.142.233:443: i/o timeout
getting upload url
Get "https://dev.macos-notary.build.10gen.cc/api/uploadurl": dial tcp 3.231.142.233:443: i/o timeout
                                                                                               
```