### PR TITLE
fix: orphan SA mongodb-enterprise-database-pods and mongodb-enterprise-ops-manager

### DIFF
--- a/mongodb-enterprise-multi-cluster.yaml
+++ b/mongodb-enterprise-multi-cluster.yaml
@@ -132,20 +132,6 @@ metadata:
   namespace: mongodb
 ---
 # Source: enterprise-operator/templates/database-roles.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: mongodb-enterprise-database-pods
-  namespace: mongodb
----
-# Source: enterprise-operator/templates/database-roles.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: mongodb-enterprise-ops-manager
-  namespace: mongodb
----
-# Source: enterprise-operator/templates/database-roles.yaml
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/mongodb-enterprise-openshift.yaml
+++ b/mongodb-enterprise-openshift.yaml
@@ -132,20 +132,6 @@ metadata:
   namespace: mongodb
 ---
 # Source: enterprise-operator/templates/database-roles.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: mongodb-enterprise-database-pods
-  namespace: mongodb
----
-# Source: enterprise-operator/templates/database-roles.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: mongodb-enterprise-ops-manager
-  namespace: mongodb
----
-# Source: enterprise-operator/templates/database-roles.yaml
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/mongodb-enterprise.yaml
+++ b/mongodb-enterprise.yaml
@@ -132,20 +132,6 @@ metadata:
   namespace: mongodb
 ---
 # Source: enterprise-operator/templates/database-roles.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: mongodb-enterprise-database-pods
-  namespace: mongodb
----
-# Source: enterprise-operator/templates/database-roles.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: mongodb-enterprise-ops-manager
-  namespace: mongodb
----
-# Source: enterprise-operator/templates/database-roles.yaml
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
We have noticed instances of orphan resources in your Kubernetes configuration files. Deploying Kubernetes resources that are not being actively used or referenced by any other resources in the cluster can lead to orphan resources. These orphan resources consume unnecessary resources and can potentially cause confusion or clutter within the cluster.  Additionally, we provide anecdotal evidence from [topolvm-topolvm#484](https://github.com/topolvm/topolvm/issues/484) regarding the orphan resource defect.

SA mongodb-enterprise-database-pods and mongodb-enterprise-ops-manager do not bind to any role or cluster role, and they can be considered orphan resources. 

delete mongodb-enterprise-database-pods and mongodb-enterprise-ops-manager or bind them to a role or cluster role.

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

